### PR TITLE
multi-line expressions (sort of)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 *~
+compiled/

--- a/static/js/tryrkt.js
+++ b/static/js/tryrkt.js
@@ -165,6 +165,11 @@ function onHandle(line, report) {
         return [{msg: data.message, className: "jquery-console-message-error"}];
     }
     
+    if (data.newline) {
+        // FIXME: how can I make it so that a new prompt doesn't appear?
+        return [{msg: "", newPrompt: false}];
+    }
+    
     // handle page
     if (currentPage >= 0 && pageExitConditions[currentPage].verify(data)) {
   			goToPage(currentPage + 1);


### PR DESCRIPTION
This is not a good solution, but I think it's better than the current behavior.
Right now, you can't type a multi-line expression at all, and some of the things in the tutorials require multiple lines.  
With my version, you get weirdness with prompts, and also an extra set!ed variable.  
if you type this:
`> (define (f x)`
and then hit enter, it will show a new prompt.
Then you can finish the expression after that:
`> (define (f x)`
`>   x)`
`> (f 1)`
`1`
