### PR TITLE
Revert "multi-line expressions (sort of)"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 .DS_Store
 *~
-compiled/

--- a/main.rkt
+++ b/main.rkt
@@ -34,8 +34,7 @@
                  [sandbox-error-output 'string]
                  [sandbox-propagate-exceptions #f]
                  [sandbox-eval-limits (list 10 50)]
-                 [sandbox-path-permissions '((read #rx#"racket-prefs.rktd")
-                                             (read #rx#"org.racket-lang.prefs.rktd"))])
+                 [sandbox-path-permissions '((read #rx#"racket-prefs.rktd"))])
     ((lambda () 
        (make-evaluator 'racket/base
                        #:requires `(pict
@@ -119,17 +118,17 @@
 
 ;; Links page
 (define (links request)
-  (make-response
-   (include-template "templates/links.html"))) 
+    (make-response
+     (include-template "templates/links.html"))) 
 
 ;; About page
 (define (about request)
-  (make-response
-   (include-template "templates/about.html"))) 
+    (make-response
+     (include-template "templates/about.html"))) 
 
 ;; Home page
 (define (home request)
-  (home-with (make-ev) request))
+    (home-with (make-ev) request))
   
 (define (home-with ev request) 
   (local [(define (response-generator embed/url)
@@ -138,11 +137,11 @@
                   )
               (make-response
                (include-template "templates/home.html"))))
-          (define (next-eval request)
-            (eval-with ev request))
-          ;(define (next-complete request)(complete-with ev request))
-          ]
-    (send/suspend/dispatch response-generator)))
+            (define (next-eval request)
+              (eval-with ev request))
+            ;(define (next-complete request)(complete-with ev request))
+            ]
+      (send/suspend/dispatch response-generator)))
 
 ;; string string -> jsexpr
 (define (json-error expr msg)
@@ -155,12 +154,12 @@
 ;; string eval-result -> jsexpr
 (define (result-json expr lst)
    (match lst
-     [(list res #f #f) 
-      (json-result expr res)]
-     [(list res out #f) 
-      (json-result expr (string-append out res))]
-     [(list _ _ err)
-      (json-error expr err)]))
+     ((list res #f #f) 
+      (json-result expr res))
+     ((list res out #f) 
+      (json-result expr (string-append out res)))
+     ((list _ _ err)
+      (json-error expr err))))
 
 
 ;(module+ test
@@ -182,26 +181,14 @@
 ;   (eval-result-to-json "(begin (display \"6 + \") \"6\")") "\"6 + \\\"6\\\"\"")
 ;)  
 
-;; this variable will be mutated with set! within eval-with
-(define prev-str "")
-
 ;; Eval handler
 (define (eval-with ev request) 
   (define bindings (request-bindings request))
   (cond [(exists-binding? 'expr bindings)
          (let ([expr (extract-binding/single 'expr bindings)])
-           (define str (string-append prev-str (if (string? expr) expr (~s expr))))
-           (cond [(with-handlers ([exn:fail:read:eof? (λ (e) #f)])
-                    (read (open-input-string str)) #t)
-                  (set! prev-str "")
-                  (make-response
-                   #:mime-type APPLICATION/JSON-MIME-TYPE
-                   (jsexpr->json (result-json str (run-code ev str))))]
-                 [else
-                  (set! prev-str (string-append str "\n"))
-                  (make-response
-                   #:mime-type APPLICATION/JSON-MIME-TYPE
-                   (jsexpr->json (hasheq "newline" #t)))]))]
+           (make-response 
+            #:mime-type APPLICATION/JSON-MIME-TYPE
+            (jsexpr->json (result-json expr (run-code ev expr)))))]
          [(exists-binding? 'complete bindings)
           (let ([str (extract-binding/single 'complete bindings)])
             (make-response 

--- a/static/js/tryrkt.js
+++ b/static/js/tryrkt.js
@@ -165,11 +165,6 @@ function onHandle(line, report) {
         return [{msg: data.message, className: "jquery-console-message-error"}];
     }
     
-    if (data.newline) {
-        // FIXME: how can I make it so that a new prompt doesn't appear?
-        return [{msg: "", newPrompt: false}];
-    }
-    
     // handle page
     if (currentPage >= 0 && pageExitConditions[currentPage].verify(data)) {
   			goToPage(currentPage + 1);


### PR DESCRIPTION
Reverts jarcane/try-racket#2

This seems to break printing, I'm afraid. Reverting this for now, looks like another solution may be needed. 
